### PR TITLE
Add private_code module support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+private_code.py

--- a/20250601_alibaba_scraper.py
+++ b/20250601_alibaba_scraper.py
@@ -15,6 +15,12 @@ from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 from webdriver_manager.chrome import ChromeDriverManager
 
+# Optional private helpers or data
+try:
+    from private_code import *  # noqa: F401,F403
+except Exception:
+    pass
+
 APP_BG = "#181D23"
 FRAME_BG = "#222831"
 ENTRY_BG = "#323943"

--- a/20250601_mercari_scraper.py
+++ b/20250601_mercari_scraper.py
@@ -13,6 +13,12 @@ from selenium.webdriver.chrome.options import Options
 from selenium.webdriver.chrome.service import Service
 from webdriver_manager.chrome import ChromeDriverManager
 
+# Optional private helpers or data
+try:
+    from private_code import *  # noqa: F401,F403
+except Exception:
+    pass
+
 # UI設定
 APP_BG = "#181D23"
 FRAME_BG = "#222831"

--- a/README.md
+++ b/README.md
@@ -1,0 +1,12 @@
+# Scraping Tools
+
+This repository contains simple scrapers for Alibaba and Mercari.
+
+## Private Code
+
+The scripts expect a `private_code.py` file to be present in the project
+root. This file can contain any functions or data that you prefer not to
+share publicly, such as API keys or helper functions.
+
+`private_code.py` is listed in `.gitignore` so it will not be committed.
+Create your own version of this file before running the scrapers.


### PR DESCRIPTION
## Summary
- add `.gitignore` entry for private modules
- make new README with instructions about `private_code.py`
- update both scraper scripts to optionally import from `private_code.py`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683bc77997c08321b594ec4a672d24cc