### PR TITLE
Remove core logic from public scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,13 @@ share publicly, such as API keys or helper functions.
 
 `private_code.py` is listed in `.gitignore` so it will not be committed.
 Create your own version of this file before running the scrapers.
+
+### Required Functions
+
+Core scraping logic has been moved into `private_code.py` to keep it
+private. Implement at least the following functions in your own copy of
+`private_code.py`:
+
+- `normalize_option_name`, `extract_price_1688`, and `process_excel` for
+  the Alibaba scraper.
+- `extract_price` and `process_excel` for the Mercari scraper.


### PR DESCRIPTION
## Summary
- expect main scraping functions in `private_code.py`
- drop scraping implementations from the public scripts
- document required private functions

## Testing
- `pytest -q`
- `python -m py_compile 20250601_alibaba_scraper.py 20250601_mercari_scraper.py`


------
https://chatgpt.com/codex/tasks/task_e_683bc9e156288321a400665dedb490f3